### PR TITLE
Removed no longer needed table html

### DIFF
--- a/views/reporting_unit_events.erb
+++ b/views/reporting_unit_events.erb
@@ -93,8 +93,7 @@
 
         </dl>
         <% end %>
-      </tbody>
-    </table>
+
   <% else %>
     <p id="information"><strong>There are no Respondents for this Reporting Unit.</strong></p>
   <% end %>


### PR DESCRIPTION
I'd left a closing `</tbody>` and `</table>` in earlier changes, now removed.